### PR TITLE
Fixing reset_targets()

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -324,7 +324,7 @@ function reset_targets()
 	local towers = table.filter(global.microwaves, function(e) return (e.entity and e.entity.valid) end)
 	table.each(towers, function(tower)
 		if ( tower.entity and tower.entity.valid and tower.target and tower.target.valid ) then
-			if ( tower.target.force == tower.entity.force ) then
+			if ( tower.target.force == tower.entity.force and tower.entity.surface.index == tower.target.surface.index ) then
 				--
 			else 
 				tower.target = nil


### PR DESCRIPTION
Entering to a different surface makes the game crash:

```
Error while running event camedo-microwave::on_tick (ID 0)
LuaEntity belongs to surface Factory floor 4 (index 6) but a LuaEntity belonging to surface nauvis (index 1) was expected.
stack traceback:
 [C]: in function 'create_entity'
 __camedo-microwave__/control.lua:78: in function 'update_microwave_beam'
 __camedo-microwave__/control.lua:295: in function 'func'
 __camedo-microwave__/stdlib/table.lua:91: in function 'each'
 __camedo-microwave__/control.lua:275: in function <__camedo-microwave__/control.lua:269>
```

This change removes a tower's target if it is in a different surface.